### PR TITLE
Added `ShareOfRevenueReserve` to financial models

### DIFF
--- a/SFB.Artifacts.ApplicationCore/Entities/SchoolTrustFinancialDataObject.cs
+++ b/SFB.Artifacts.ApplicationCore/Entities/SchoolTrustFinancialDataObject.cs
@@ -274,6 +274,9 @@ namespace SFB.Web.ApplicationCore.Entities
 
         [JsonProperty(PropertyName = SchoolTrustFinanceDataFieldNames.REVENUE_RESERVE)]
         public decimal? RevenueReserve { get; set; }
+        
+        [JsonProperty(PropertyName = SchoolTrustFinanceDataFieldNames.SHARE_OF_REVENUE_RESERVE)]
+        public decimal? ShareOfRevenueReserve { get; set; }
 
         [JsonProperty(PropertyName = SchoolTrustFinanceDataFieldNames.NO_PUPILS)]
         public decimal? NoPupils { get; set; }

--- a/SFB.Artifacts.ApplicationCore/Helpers/Constants/Constants.cs
+++ b/SFB.Artifacts.ApplicationCore/Helpers/Constants/Constants.cs
@@ -197,6 +197,7 @@
         public const string COMMUNITY_EXP = "Community Exp";
         public const string TOTAL_EXP = "Total Expenditure";
         public const string REVENUE_RESERVE = "Revenue Reserve";
+        public const string SHARE_OF_REVENUE_RESERVE = "Share of Revenue Reserve";
         public const string NO_TEACHERS = "No Teachers";
         public const string MEMBER_COUNT = "MemberCount";
         public const string PARTIAL_YEARS_PRESENT = "PartialYearsPresent";

--- a/SFB.Artifacts.ApplicationCore/Models/FinancialDataModel.cs
+++ b/SFB.Artifacts.ApplicationCore/Models/FinancialDataModel.cs
@@ -208,6 +208,7 @@ namespace SFB.Web.ApplicationCore.Models
 
         public decimal? InYearBalance => FinancialDataObjectModel?.InYearBalance;
         public decimal? RevenueReserve => FinancialDataObjectModel?.RevenueReserve;
+        public decimal? ShareOfRevenueReserve => FinancialDataObjectModel?.ShareOfRevenueReserve;
 
         //public bool IsFederation => FinancialDataObjectModel != null ? FinancialDataObjectModel.IsFederation : false;
         //public bool IsPartOfFederation => FinancialDataObjectModel != null ? FinancialDataObjectModel.IsPartOfFederation : false;


### PR DESCRIPTION
Above field is relevant to Academies only. It was previously in the AAR but never persisted for use by SFB.

[AB#63985](https://agilefactory.visualstudio.com/fc33e3f0-e73b-466d-837a-10cad68c664e/_workitems/edit/63985) [AB#64341](https://agilefactory.visualstudio.com/fc33e3f0-e73b-466d-837a-10cad68c664e/_workitems/edit/64341)