### PR TITLE
Mapped additional `PRE_16_FUNDING` field constant for Academy usage

### DIFF
--- a/SFB.Artifacts.ApplicationCore/Entities/SchoolTrustFinancialDataObject.cs
+++ b/SFB.Artifacts.ApplicationCore/Entities/SchoolTrustFinancialDataObject.cs
@@ -236,6 +236,9 @@ namespace SFB.Web.ApplicationCore.Entities
         [JsonProperty(PropertyName = SchoolTrustFinanceDataFieldNames.COMM_FOCUSED_SCHOOL)]
         public decimal? CommunityFocusedSchoolCosts { get; set; }
 
+        [JsonProperty(PropertyName = SchoolTrustFinanceDataFieldNames.PRE_16_FUNDING)]
+        public decimal? Pre16Funding { get; set; }
+        
         [JsonProperty(PropertyName = SchoolTrustFinanceDataFieldNames.PRE_POST_16_FUNDING)]
         public decimal? PrePost16Funding { get; set; }
 

--- a/SFB.Artifacts.ApplicationCore/Helpers/Constants/Constants.cs
+++ b/SFB.Artifacts.ApplicationCore/Helpers/Constants/Constants.cs
@@ -208,7 +208,8 @@
         public const string DNS = "DNS";
         public const string MAT_SAT = "MAT SAT or Central Services";
         public const string WORKFORCE_PRESENT = "WorkforcePresent";
-        public const string PRE_POST_16_FUNDING = "Pre-16 and 6th form funding"; // #64500
+        public const string PRE_16_FUNDING = "Pre-16 Funding";                   // #64500 (for Academy pre-/post-16 funding)
+        public const string PRE_POST_16_FUNDING = "Pre-16 and 6th form funding"; // #64500 (for Maintained pre-/post-16 funding)
         public const string ADDITIONAL_GRANT = "Additional grant for schools";
         public const string PUPIL_FOCUSED_FUNDING = "Pupil focussed extended school funding and/or grants";
         public const string PUPIL_PREMIUM = "Pupil Premium";


### PR DESCRIPTION
As agreed in [AB#64500](https://agilefactory.visualstudio.com/fc33e3f0-e73b-466d-837a-10cad68c664e/_workitems/edit/64500), a different field will be consumed for Academies than Maintained schools due to transformation inconsistencies in these fields.